### PR TITLE
Add a Fat Beacon support and an example

### DIFF
--- a/examples/fatBeacon/simple.js
+++ b/examples/fatBeacon/simple.js
@@ -4,13 +4,16 @@ var eddystoneBeacon = require('./../../index');
 
 var html = "<html>" + 
       "<head>" +
-        "<title>Fat Beacon Demo2</title>" +
+        "<title>Fat Beacon Demo</title>" +
         "<meta charset='UTF-8'>" + 
         "<meta name='description' content='Fat Beacon Demo'/>" + 
        "</head>" + 
        "<body>" +
         "<h1>HelloWorld</h1>" +
         "This is a test" + 
+        "<div>Adding more content to see if I can it over the MTU value</div>" + 
+        "<div>Adding more content to see if I can it over the MTU value</div>" + 
+        "<div>Adding more content to see if I can it over the MTU value</div>" + 
        "</body>" + 
       "</html>";
 

--- a/examples/fatBeacon/simple.js
+++ b/examples/fatBeacon/simple.js
@@ -4,12 +4,14 @@ var eddystoneBeacon = require('./../../index');
 
 var html = "<html>" + 
       "<head>" +
-       "<title>Fat Beacon Demo</title>" +
-       "<meta name='description' content='FatBeacon Demo'/>"
-      "</head>" + 
-      "<body>" +
-       "<h1>HelloWorld</h1>"
-      "</body>" + 
-       "</html>";
+        "<title>Fat Beacon Demo2</title>" +
+        "<meta charset='UTF-8'>" + 
+        "<meta name='description' content='Fat Beacon Demo'/>" + 
+       "</head>" + 
+       "<body>" +
+        "<h1>HelloWorld</h1>" +
+        "This is a test" + 
+       "</body>" + 
+      "</html>";
 
 eddystoneBeacon.advertiseFatBeacon('Fat Beacon Demo', {html: html});

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -16,13 +16,21 @@
 var bleno = require('bleno');
 var util = require('util');
 
+var currentMTU = 0;
+var queueOffset = 0;
 
 bleno.on('mtuChange', function(mtu) {
-  console.log('on -> mtuChange: ' + mtu);
+  //console.log('on -> mtuChange: ' + mtu);
+  currentMTU = mtu;
+});
+
+bleno.on('accept', function(){
+  queueOffset = 0;
 });
 
 function HTMLCharacteristic(html) {
   this._html = html;
+  this._buffer = new Buffer(this._html, 'utf8');
   bleno.Characteristic.call(this, {
     uuid: 'd1a517f0249946ca9ccc809bc1c966fa',
     properties: ['read'],
@@ -38,12 +46,16 @@ function HTMLCharacteristic(html) {
 util.inherits(HTMLCharacteristic,bleno.Characteristic);
 
 HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
-  var buf = new Buffer(this._html, 'utf8');
-  if (offset < buf.length) {
-    var slice = buf.slice(offset);
+  //var buf = new Buffer(this._html, 'utf8');
+  if (queueOffset < this._buffer.length) {
+    var transfer = currentMTU - 5;
+    var end = queueOffset + transfer >= this._buffer.length ? this._buffer.length: queueOffset + transfer;
+    var slice = this._buffer.slice(queueOffset, end);
     callback(this.RESULT_SUCCESS, slice);
-  } else {
-    //problem
+    queueOffset = end;
+  } else if (queueOffset === this._buffer.length) {
+    callback(this.RESULT_SUCCESS, new Buffer());
+    queueOffset++;
   }
 
 }

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -17,6 +17,10 @@ var bleno = require('bleno');
 var util = require('util');
 
 
+bleno.on('mtuChange', function(mtu) {
+  console.log('on -> mtuChange: ' + mtu);
+});
+
 function HTMLCharacteristic(html) {
   this._html = html;
   bleno.Characteristic.call(this, {
@@ -34,7 +38,6 @@ function HTMLCharacteristic(html) {
 util.inherits(HTMLCharacteristic,bleno.Characteristic);
 
 HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
-  console.log("read request");
   var buf = new Buffer(this._html, 'utf8');
   if (offset < buf.length) {
     var slice = buf.slice(offset);

--- a/lib/util/advertisement-data.js
+++ b/lib/util/advertisement-data.js
@@ -63,7 +63,7 @@ var makeFatBeaconBuffer = function (title, txPowerLevel) {
     var data = Buffer.concat([
         txPowerLevelData,
         new Buffer([0x0E]),
-        Buffer.from(title)
+        new Buffer(title)
     ]);
 
     return makeEddystoneBuffer(URL_FRAME_TYPE, data);


### PR DESCRIPTION
Based on the discussion in https://github.com/google/physical-web/issues/814 this should add Fat Beacon support to node-eddystone-beacon 
